### PR TITLE
Change Model to be a type family

### DIFF
--- a/src/Test/QuickCheck/Classes.hs
+++ b/src/Test/QuickCheck/Classes.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, FlexibleContexts, KindSignatures
-           , Rank2Types, TypeOperators, CPP
+           , Rank2Types, TypeOperators, CPP, TypeFamilies
   #-}
 
 ----------------------------------------------------------------------
@@ -110,7 +110,8 @@ ordMorphism h = ( "ord morphism"
 
 -- | The semantic function ('model') for @a@ is an 'ordMorphism'.
 semanticOrd :: forall a b.
-  ( Model a b
+  ( b ~ ModelOf a
+  , Model a
   , Ord a, Ord b
   , Show a
   , Arbitrary a
@@ -171,7 +172,8 @@ monoidMorphism :: (Monoid a, Monoid b, EqProp b, Show a, Arbitrary a) =>
 monoidMorphism q = ("monoid morphism", homomorphism monoidD monoidD q)
 
 semanticMonoid :: forall a b.
-  ( Model a b
+  ( b ~ ModelOf a
+  , Model a
   , Monoid a, Monoid b
   , Show a
   , Arbitrary a


### PR DESCRIPTION
This PR changes Model from a fundep to a type family, and adds some obviously missing instances. The rationale is below.

---

The encoding of `Model` as a fundep is somewhat problematic, as it gives us nothing to "hold on to" when wanting to give the types of function denotations.

For example, if we want to encode the following denotation in haskell:

```haskell
data System
μ System = (Id, M.Map Id Entity)

data Setter 
μ Setter = Entity -> Maybe Entity

data Query a 
μ Query a = System -> Entity -> Maybe a

setEntity :: Id -> Setter -> System -> System

newEntity :: Setter -> System -> (System, Id)
μ newEntity set sys =
  let (ix, m) = μ sys
   in (setEntity ix set (φ (ix + 1, m)), ix)  -- φ is the inverse of μ
```

We can model the μ for the types via `instance Model T (μ T)`. However, because there is no guarantee that φ exists, the only compositional definition we can give for `μ newEntity` is to replace everything (the arguments, result, and other calls in the design) with their models:

```haskell
m_newEntity m_set m_sys =
  let (ix, m) = m_sys
   in (m_setEntity ix m_set (ix + 1, m), ix)
```

But the type of `m_newEntity` is now:

```haskell
(Entity -> Maybe Entity) -> (Id, M.Map Id Entity) -> ((Id, M.Map Id Entity), Id)
```

which bears no resemblance to the type of `newEntity`, leaks the model, and it makes it harder to change our minds later. By instead changing the fundep of Model to a type family, we can instead give it the much nicer type:

```haskell
ModelOf Setter -> ModelOf System -> ModelOf (System, Id)
```