### PR TITLE
Restore verboseBatch functionality

### DIFF
--- a/checkers.cabal
+++ b/checkers.cabal
@@ -1,5 +1,5 @@
 Name:                checkers
-Version:             0.5.6
+Version:             0.5.7
 Cabal-Version:       >= 1.10
 Synopsis:            Check properties on standard classes and data structures.
 Category:            Testing

--- a/src/Test/QuickCheck/Checkers.hs
+++ b/src/Test/QuickCheck/Checkers.hs
@@ -97,6 +97,7 @@ unbatch :: TestBatch -> [Test]
 unbatch (batchName,props) = map (first ((batchName ++ ": ")++)) props
 
 -- TODO: consider a tree structure so that flattening is unnecessary.
+
 type QuickCheckRunner = Args -> Property -> IO ()
 
 -- | Run a batch of tests.  See 'quickBatch' and 'verboseBatch'.


### PR DESCRIPTION
Looks like `verboseBatch` has just been another name for `quickBatch` for quite some time!

QuickCheck has a [`verboseCheckWith`](https://hackage.haskell.org/package/QuickCheck2.14.2/docs/src/Test.QuickCheck.Test.html#verboseCheckWith) that's essentially the same as the `quickCheckWith` we're already using:

```
verboseCheckWith :: Testable prop => Args -> prop -> IO ()
verboseCheckWith args p = quickCheckWith args (verbose p)
```

I believe it's what we're looking for in order to make `verboseBatch` verbose again.