### PR TITLE
Remove redundant constraint from instance CoArbitrary Array

### DIFF
--- a/src/Test/QuickCheck/Instances/Array.hs
+++ b/src/Test/QuickCheck/Instances/Array.hs
@@ -1,19 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
-#if MIN_VERSION_base(4,9,0)
--- https://github.com/conal/checkers/pull/38
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
-#endif
 
 module Test.QuickCheck.Instances.Array where
 
 import Test.QuickCheck
 import Data.Array
 
--- The redundant (Ix a) constraint is required with GHC-7.10.
 instance (Ix a, Integral a, Arbitrary b) => Arbitrary (Array a b) where
   arbitrary   =
     (\x -> listArray (0,fromIntegral (length x - 1)) x) <$> arbitrary
 
-instance (Ix a, CoArbitrary b) => CoArbitrary (Array a b) where
+instance (CoArbitrary b) => CoArbitrary (Array a b) where
   coarbitrary = coarbitrary . elems


### PR DESCRIPTION
We can do this now that we've dropped support for GHC 7.10
in #63.